### PR TITLE
ASDPLNG-595: Allow sshd banner skipped even if banner content set

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,19 @@ specified sources.
 
 ## Reference
 
+[REFERENCE.md](REFERENCE.md)
+
 ### define sshd::allow_from (
 -    Array[ String, 1 ]   $hostlist,
 -    Array[ String ]      $users                   = [],
 -    Array[ String ]      $groups                  = [],
 -    Hash[ String, Data ] $additional_match_params = {},
 ### class sshd (
--    Array             $trusted_subnets,
+-    Boolean           $banner_ignore,
 -    Hash              $config,
 -    Hash[String,Hash] $config_matches,
+-    Array[String]     $required_packages,
 -    Array[String]     $revoked_keys,
--    String            $banner,
-
--    # Module defaults should be sufficient
--    Array[String] $required_packages,   #per OS
--    String        $revoked_keys_file,   #per OS
-
-[REFERENCE.md](REFERENCE.md)
+-    String            $revoked_keys_file,
+-    Array             $trusted_subnets,
+-    Optional[String]  $banner = undef,

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -34,6 +34,7 @@ The following parameters are available in the `sshd` class:
 * [`config`](#config)
 * [`config_matches`](#config_matches)
 * [`banner`](#banner)
+* [`banner_ignore`](#banner_ignore)
 * [`revoked_keys`](#revoked_keys)
 * [`required_packages`](#required_packages)
 * [`revoked_keys_file`](#revoked_keys_file)
@@ -94,12 +95,18 @@ Example of hiera data:
 ```
 sshd::banner: |2+
 
-Login with NCSA Kerberos + Duo multi-factor.
+  Login with NCSA Kerberos + NCSA Duo multi-factor.
 
-DUO Documentation:  https://go.ncsa.illinois.edu/2fa
+  DUO Documentation:  https://go.ncsa.illinois.edu/2fa
 ```
 
 Default value: ``undef``
+
+##### <a name="banner_ignore"></a>`banner_ignore`
+
+Data type: `Boolean`
+
+Disable setting banner in sshd even if banner content is set
 
 ##### <a name="revoked_keys"></a>`revoked_keys`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,6 +11,7 @@ lookup_options:
   sshd::trusted_subnets:
     merge: "deep"
 
+sshd::banner_ignore: false
 sshd::config_matches: {}
 sshd::revoked_keys: []
 sshd::trusted_subnets: []

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,10 +45,14 @@
 #   ```
 #   sshd::banner: |2+
 #
-#   Login with NCSA Kerberos + Duo multi-factor.
+#     Login with NCSA Kerberos + NCSA Duo multi-factor.
 #
-#   DUO Documentation:  https://go.ncsa.illinois.edu/2fa
+#     DUO Documentation:  https://go.ncsa.illinois.edu/2fa
 #   ```
+#
+# @param banner_ignore
+#   Disable setting banner in sshd even if banner content is set
+#
 # @param revoked_keys
 #   List of ssh public keys to disallow.
 #   Values from multiple sources are merged.
@@ -60,6 +64,7 @@
 # @example
 #   include sshd
 class sshd (
+  Boolean           $banner_ignore,
   Hash              $config,
   Hash[String,Hash] $config_matches,
   Array[String]     $required_packages,   #per OS
@@ -160,7 +165,7 @@ class sshd (
   }
 
   #SSH Banner creation
-  if ($banner != undef) {
+  if ($banner != undef and ! $banner_ignore ) {
     file { '/etc/sshbanner':
       ensure  => file,
       content => $banner,


### PR DESCRIPTION
See: https://jira.ncsa.illinois.edu/browse/ASDPLNG-595

This is being tested on `linux-test` & `dt-login03.delta`.

I'm wanting to include this in changes being applied to the main public `linux` server tomorrow morning.