### PR TITLE
SVC-16496: Allow for sshd service to not be managed

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -30,21 +30,43 @@ include sshd
 
 The following parameters are available in the `sshd` class:
 
-* [`trusted_subnets`](#trusted_subnets)
-* [`config`](#config)
-* [`config_matches`](#config_matches)
 * [`banner`](#banner)
 * [`banner_ignore`](#banner_ignore)
-* [`revoked_keys`](#revoked_keys)
+* [`config`](#config)
+* [`config_file`](#config_file)
+* [`config_matches`](#config_matches)
+* [`config_subsystems`](#config_subsystems)
+* [`manage_service`](#manage_service)
 * [`required_packages`](#required_packages)
+* [`revoked_keys`](#revoked_keys)
 * [`revoked_keys_file`](#revoked_keys_file)
+* [`service_name`](#service_name)
+* [`trusted_subnets`](#trusted_subnets)
 
-##### <a name="trusted_subnets"></a>`trusted_subnets`
+##### <a name="banner"></a>`banner`
 
-Data type: `Array`
+Data type: `Optional[String]`
 
-Array of IPs and CIDRs to be allowed through the firewall
-Values from multiple sources are merged
+A string to create a banner to display before login.
+Use to display before authentication.
+Defining this automatically sets the sshd_config option.
+If you define the Banner config in hiera, the Puppet agent will not run.
+Example of hiera data:
+```
+sshd::banner: |2+
+
+  Login with NCSA Kerberos + NCSA Duo multi-factor.
+
+  DUO Documentation:  https://go.ncsa.illinois.edu/2fa
+```
+
+Default value: ``undef``
+
+##### <a name="banner_ignore"></a>`banner_ignore`
+
+Data type: `Boolean`
+
+Disable setting banner in sshd even if banner content is set
 
 ##### <a name="config"></a>`config`
 
@@ -54,6 +76,12 @@ Hash of global config settings
 Defaults provided by this module
 Values from multiple sources are merged
 Key collisions are resolved in favor of the higher priority value
+
+##### <a name="config_file"></a>`config_file`
+
+Data type: `String`
+
+Full path to sshd_config file
 
 ##### <a name="config_matches"></a>`config_matches`
 
@@ -83,37 +111,17 @@ Merges are deep to allow use of the knockout_prefix '-' (to remove a key
 from the final result).
 ```
 
-##### <a name="banner"></a>`banner`
+##### <a name="config_subsystems"></a>`config_subsystems`
 
-Data type: `Optional[String]`
+Data type: `Hash`
 
-A string to create a banner to display before login.
-Use to display before authentication.
-Defining this automatically sets the sshd_config option.
-If you define the Banner config in hiera, the Puppet agent will not run.
-Example of hiera data:
-```
-sshd::banner: |2+
+Hash of sshd subsystems to enable and configure
 
-  Login with NCSA Kerberos + NCSA Duo multi-factor.
-
-  DUO Documentation:  https://go.ncsa.illinois.edu/2fa
-```
-
-Default value: ``undef``
-
-##### <a name="banner_ignore"></a>`banner_ignore`
+##### <a name="manage_service"></a>`manage_service`
 
 Data type: `Boolean`
 
-Disable setting banner in sshd even if banner content is set
-
-##### <a name="revoked_keys"></a>`revoked_keys`
-
-Data type: `Array[String]`
-
-List of ssh public keys to disallow.
-Values from multiple sources are merged.
+Flag of whether to manage sshd service
 
 ##### <a name="required_packages"></a>`required_packages`
 
@@ -122,11 +130,31 @@ Data type: `Array[String]`
 List of package names to be installed (OS specific).
 (Defaults provided by module should be sufficient).
 
+##### <a name="revoked_keys"></a>`revoked_keys`
+
+Data type: `Array[String]`
+
+List of ssh public keys to disallow.
+Values from multiple sources are merged.
+
 ##### <a name="revoked_keys_file"></a>`revoked_keys_file`
 
 Data type: `String`
 
+Full path to name of revoked keys file
 
+##### <a name="service_name"></a>`service_name`
+
+Data type: `String`
+
+Name os sshd service
+
+##### <a name="trusted_subnets"></a>`trusted_subnets`
+
+Data type: `Array`
+
+Array of IPs and CIDRs to be allowed through the firewall
+Values from multiple sources are merged
 
 ## Defined types
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,6 +12,8 @@ lookup_options:
     merge: "deep"
 
 sshd::banner_ignore: false
+sshd::config_file: "/etc/ssh/sshd_config"
 sshd::config_matches: {}
+sshd::manage_service: true
 sshd::revoked_keys: []
 sshd::trusted_subnets: []

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -7,6 +7,9 @@ sshd::config:
   PermitRootLogin: "no"
   PubkeyAuthentication: "no"
   UsePAM: "yes"
+sshd::config_subsystems:
+  sftp: "/usr/libexec/openssh/sftp-server"
 sshd::required_packages:
   - "openssh-server"
 sshd::revoked_keys_file: "/etc/ssh/revoked_keys"
+sshd::service_name: "sshd"

--- a/manifests/allow_from.pp
+++ b/manifests/allow_from.pp
@@ -115,8 +115,14 @@ define sshd::allow_from (
 
   ### SSHD_CONFIG
   # Defaults
-  $config_defaults = {
-    'notify' => Service[ sshd ],
+  if ( $sshd::manage_service ) {
+    $config_defaults = {
+      'notify' => Service[$sshd::service_name],
+    }
+  } else {
+    $config_defaults = {
+      'ensure' => 'present',
+    }
   }
   $config_match_defaults = $config_defaults + {
     'position' => 'before first match'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,15 +2,31 @@
 #
 # Configure default sshd settings
 #
-# @param trusted_subnets
-#   Array of IPs and CIDRs to be allowed through the firewall
-#   Values from multiple sources are merged
+# @param banner
+#   A string to create a banner to display before login.
+#   Use to display before authentication.
+#   Defining this automatically sets the sshd_config option.
+#   If you define the Banner config in hiera, the Puppet agent will not run.
+#   Example of hiera data:
+#   ```
+#   sshd::banner: |2+
+#
+#     Login with NCSA Kerberos + NCSA Duo multi-factor.
+#
+#     DUO Documentation:  https://go.ncsa.illinois.edu/2fa
+#   ```
+#
+# @param banner_ignore
+#   Disable setting banner in sshd even if banner content is set
 #
 # @param config
 #   Hash of global config settings
 #   Defaults provided by this module
 #   Values from multiple sources are merged
 #   Key collisions are resolved in favor of the higher priority value
+#
+# @param config_file
+#   Full path to sshd_config file
 #
 # @param config_matches
 #   Hash of config "match" conditions and settings.
@@ -36,40 +52,44 @@
 #   Merges are deep to allow use of the knockout_prefix '-' (to remove a key
 #   from the final result).
 #   ```
-# @param banner
-#   A string to create a banner to display before login.
-#   Use to display before authentication.
-#   Defining this automatically sets the sshd_config option.
-#   If you define the Banner config in hiera, the Puppet agent will not run.
-#   Example of hiera data:
-#   ```
-#   sshd::banner: |2+
 #
-#     Login with NCSA Kerberos + NCSA Duo multi-factor.
+# @param config_subsystems
+#   Hash of sshd subsystems to enable and configure
 #
-#     DUO Documentation:  https://go.ncsa.illinois.edu/2fa
-#   ```
+# @param manage_service
+#   Flag of whether to manage sshd service
 #
-# @param banner_ignore
-#   Disable setting banner in sshd even if banner content is set
+# @param required_packages
+#   List of package names to be installed (OS specific).
+#   (Defaults provided by module should be sufficient).
 #
 # @param revoked_keys
 #   List of ssh public keys to disallow.
 #   Values from multiple sources are merged.
 #
-# @param required_packages
-#   List of package names to be installed (OS specific).
-#   (Defaults provided by module should be sufficient).
+# @param revoked_keys_file
+#   Full path to name of revoked keys file
+#
+# @param service_name
+#   Name os sshd service
+#
+# @param trusted_subnets
+#   Array of IPs and CIDRs to be allowed through the firewall
+#   Values from multiple sources are merged
 #
 # @example
 #   include sshd
 class sshd (
   Boolean           $banner_ignore,
   Hash              $config,
+  String            $config_file,
   Hash[String,Hash] $config_matches,
+  Hash              $config_subsystems,
+  Boolean           $manage_service,
   Array[String]     $required_packages,   #per OS
   Array[String]     $revoked_keys,
   String            $revoked_keys_file,   #per OS
+  String            $service_name,
   Array             $trusted_subnets,
   Optional[String]  $banner = undef,
 ) {
@@ -78,12 +98,24 @@ class sshd (
   ensure_packages( $required_packages, {'ensure' => 'present'} )
 
   # SERVICE
-  service { 'sshd' :
-    ensure     => running,
-    enable     => true,
-    hasstatus  => true,
-    hasrestart => true,
-    require    => Package[ $required_packages ],
+  if ( $manage_service ) {
+    service { $service_name :
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+      require    => Package[ $required_packages ],
+    }
+    # SET DEFAULTS TO NOTIFY SERVICE
+    $config_defaults = {
+      'notify' => Service[$service_name] ,
+    }
+  } else {
+    # SET DEFAULTS TO SKIP NOTIFY SERVICE
+    # THE ENSURE => PRESENT IS A DEFAULT, BUT SETTING IT SO THAT WE CAN SET SOME DEFAULT
+    $config_defaults = {
+      'ensure' => present,
+    }
   }
 
   # FIREWALL
@@ -96,6 +128,13 @@ class sshd (
     }
   }
 
+  # SSHD CONFIG SETTINGS
+#  if ( $config_defaults ) {
+    $config_match_defaults = $config_defaults + { 'position' => 'before first match' }
+#  } else {
+#    $config_match_defaults = { 'position' => 'before first match' }
+#  }
+
   # REVOKED KEYS
   file { $revoked_keys_file :
     ensure  => present,
@@ -103,27 +142,20 @@ class sshd (
     group   => root,
     mode    => '0644',
     content => join( $revoked_keys, "\n" ),
-    notify  => Service['sshd'],
   }
   sshd_config {
     'RevokedKeys' :
       value => $revoked_keys_file,
     ;
+    default:
+      * => $config_defaults,
+    ;
   }
-
-  # SSHD CONFIG SETTINGS
-
-  # Default sshd_config attributes
-  $config_defaults = {
-    'notify' => Service[ sshd ],
-  }
-  $config_match_defaults = $config_defaults + { 'position' => 'before first match' }
 
   $puppet_file_header = '# This file is managed by Puppet - Changes may be overwritten'
-  $sshd_config_file = '/etc/ssh/sshd_config'
   exec { 'add puppet header to sshd_config':
-    command => "sed -i '1s/^/${puppet_file_header}\\n/' '${sshd_config_file}'",
-    unless  => "grep '${puppet_file_header}' ${sshd_config_file}",
+    command => "sed -i '1s/^/${puppet_file_header}\\n/' '${config_file}'",
+    unless  => "grep '${puppet_file_header}' ${config_file}",
     path    => [ '/bin', '/usr/bin' ],
   }
 
@@ -178,7 +210,23 @@ class sshd (
         'Banner' :
           value => '/etc/sshbanner',
         ;
+        default:
+          * => $config_defaults,
+        ;
       }
     }
   }
+
+  # SSHD SUBSYSTEMS, e.g. sftp
+  $config_subsystems.each | $key, $val | {
+    sshd_config_subsystem {
+      $key :
+        command => $val,
+      ;
+      default:
+        * => $config_defaults,
+      ;
+    }
+  }
+
 }


### PR DESCRIPTION
Add `$config_file`, `$manage_service`, & `$service_name` parameters
Clean up docstring documentation
Fix issue #8 support for subsystems
Fix issue #9 banner not restart service
Fix issue #12 allow for sshd service to not be managed - needed for supporting alternate SSHD, e.g. `gsi-sshd`

See: https://jira.ncsa.illinois.edu/browse/SVC-16496

This is being tested on:
- `control-test05`
- `control-test06`