### PR TITLE
SECURITY-1421 Set "AuthenticationMethods none" in global sshd_config

### DIFF
--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -2,6 +2,7 @@
 sshd::config:
   AllowGroups:
     - "root"
+  AuthenticationMethods: "none"
   DenyGroups:
     - "all_disabled_usr"
   PermitRootLogin: "no"


### PR DESCRIPTION
NOTICE!
If you are using any of the following modules, make sure you are using
at least this tag version listed:
puppet-profile_allow_ssh_from_bastion v0.2.4
puppet-profile_hostbased_ssh v1.0.1

That is because those modules at that version explicitly set the
AuthenticationMethods xxx for the match blocks that they manage

If you have any other match blocks set via some other means be
sure they also set AuthenticationMethods appropriately, since
this update sets 'AuthenticationMethods none' globally each match
block needs to define what AuthenticationMethods it needs