### PR TITLE
SVCPLAN-1702 - Add new allow_list class

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,6 +7,7 @@
 ### Classes
 
 * [`sshd`](#sshd): Configure default sshd settings
+* [`sshd::allow_list`](#sshdallow_list): Hash of allows to pass to allow_from.pp
 
 ### Defined types
 
@@ -155,6 +156,64 @@ Data type: `Array`
 
 Array of IPs and CIDRs to be allowed through the firewall
 Values from multiple sources are merged
+
+### <a name="sshdallow_list"></a>`sshd::allow_list`
+
+Hash of allows to pass to allow_from.pp
+
+#### Examples
+
+##### 
+
+```puppet
+include sshd::allow_list
+```
+
+#### Parameters
+
+The following parameters are available in the `sshd::allow_list` class:
+
+* [`allows`](#allows)
+
+##### <a name="allows"></a>`allows`
+
+Data type: `Hash`
+
+Hash to pass to allow_from.pp, where top level key is the name
+and the values under that is the hash to pass to allow_from.pp
+
+See allow_from.pp for allowed values
+
+Example:
+```
+sshd::allow_list::allows:
+  "dummyuser":
+    hostlist:
+      - "1.1.1.1"
+    users:
+      - "dummyuser"
+    additional_match_params:
+      PubkeyAuthentication: "yes"
+      AuthenticationMethods: "publickey"
+      Banner: "none"
+      MaxAuthTries: "6"
+      MaxSessions: "10"
+      X11Forwarding: "no"
+      AuthorizedKeysFile: "/delta/home/keys/%u"
+  "dummygroup":
+    hostlist:
+      - "2.2.2.2"
+    groups:
+      - "dummygroup"
+    additional_match_params:
+      PubkeyAuthentication: "yes"
+      AuthenticationMethods: "publickey"
+      Banner: "none"
+      MaxAuthTries: "6"
+      MaxSessions: "10"
+      X11Forwarding: "no"
+      AuthorizedKeysFile: "/delta/home/keys/%u"
+```
 
 ## Defined types
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,9 @@
 ---
 lookup_options:
+  sshd::allow_list::allows:
+    merge:
+      strategy: "deep"
+      knockout_prefix: "-"
   sshd::config:
     merge: "hash"
   sshd::config_matches:
@@ -10,6 +14,8 @@ lookup_options:
     merge: "deep"
   sshd::trusted_subnets:
     merge: "deep"
+
+sshd::allow_list::allows: {}
 
 sshd::banner_ignore: false
 sshd::config_file: "/etc/ssh/sshd_config"

--- a/manifests/allow_list.pp
+++ b/manifests/allow_list.pp
@@ -1,0 +1,49 @@
+# @summary Hash of allows to pass to allow_from.pp
+#
+# @param allows
+#   Hash to pass to allow_from.pp, where top level key is the name
+#   and the values under that is the hash to pass to allow_from.pp
+#
+#   See allow_from.pp for allowed values
+#
+#   Example:
+#   ```
+#   sshd::allow_list::allows:
+#     "dummyuser":
+#       hostlist:
+#         - "1.1.1.1"
+#       users:
+#         - "dummyuser"
+#       additional_match_params:
+#         PubkeyAuthentication: "yes"
+#         AuthenticationMethods: "publickey"
+#         Banner: "none"
+#         MaxAuthTries: "6"
+#         MaxSessions: "10"
+#         X11Forwarding: "no"
+#         AuthorizedKeysFile: "/delta/home/keys/%u"
+#     "dummygroup":
+#       hostlist:
+#         - "2.2.2.2"
+#       groups:
+#         - "dummygroup"
+#       additional_match_params:
+#         PubkeyAuthentication: "yes"
+#         AuthenticationMethods: "publickey"
+#         Banner: "none"
+#         MaxAuthTries: "6"
+#         MaxSessions: "10"
+#         X11Forwarding: "no"
+#         AuthorizedKeysFile: "/delta/home/keys/%u"
+#   ```
+#
+# @example
+#   include sshd::allow_list
+class sshd::allow_list (
+  Hash $allows,
+) {
+
+  $allows.each | $name, $v | {
+    sshd::allow_from { $name: * => $v }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,8 @@ class sshd (
   Optional[String]  $banner = undef,
 ) {
 
+  include sshd::allow_list
+
   # PACKAGES
   ensure_packages( $required_packages, {'ensure' => 'present'} )
 

--- a/spec/classes/allow_list_spec.rb
+++ b/spec/classes/allow_list_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'sshd::allow_list' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
Adding an allow_list class that will allow more flexible edits to
sshd_config that what is currently possible with other modules
like puppet-profile_allow_ssh_from_bastion