### PR TITLE
SVCPLAN-2993 Turn on verbose SFTP sshd subsystem by default

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -13,14 +13,18 @@ https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/pupp
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"settings": {
 		"terminal.integrated.profiles.linux": {
 			"bash": {
-				"path": "bash",
+				"path": "bash"
 			}
 		}
 	},

--- a/.github/workflows/pdk-validate.yml
+++ b/.github/workflows/pdk-validate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Clone repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Run pdk validate"
         uses: "puppets-epic-show-theatre/action-pdk-validate@v1"
         with:

--- a/.pdkignore
+++ b/.pdkignore
@@ -39,7 +39,6 @@
 /rakelib/
 /.rspec
 /.rubocop.yml
-/.travis.yml
 /.yardopts
 /spec/
 /.vscode/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.4'
+  TargetRubyVersion: '2.5'
   Include:
   - "**/*.rb"
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -13,21 +13,31 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 group :development do
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',   require: false
+  gem "facterdb", '~> 1.18',                       require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0', require: false
+  gem "puppetlabs_spec_helper", '~> 5.0',          require: false
+  gem "rspec-puppet-facts", '~> 2.0',              require: false
+  gem "codecov", '~> 0.2',                         require: false
+  gem "dependency_checker", '~> 0.2',              require: false
+  gem "parallel_tests", '= 3.12.1',                require: false
+  gem "pry", '~> 0.10',                            require: false
+  gem "simplecov-console", '~> 0.5',               require: false
+  gem "puppet-debugger", '~> 1.0',                 require: false
+  gem "rubocop", '= 1.6.1',                        require: false
+  gem "rubocop-performance", '= 1.9.1',            require: false
+  gem "rubocop-rspec", '= 2.0.1',                  require: false
+  gem "rb-readline", '= 0.5.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby, :x64_mingw]
+  gem "serverspec", '~> 2.41',    require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -9,7 +9,7 @@ sshd::config:
   PubkeyAuthentication: "no"
   UsePAM: "yes"
 sshd::config_subsystems:
-  sftp: "/usr/libexec/openssh/sftp-server"
+  sftp: "/usr/libexec/openssh/sftp-server -l VERBOSE"
 sshd::required_packages:
   - "openssh-server"
 sshd::revoked_keys_file: "/etc/ssh/revoked_keys"

--- a/manifests/allow_from.pp
+++ b/manifests/allow_from.pp
@@ -40,38 +40,35 @@
 #       'additional_match_params' => Hash,
 #   }
 define sshd::allow_from (
-  Array[ String, 1 ]   $hostlist,
-  Array[ String ]      $users                   = [],
-  Array[ String ]      $groups                  = [],
-  Hash[ String, Data ] $additional_match_params = {},
+  Array[String, 1]   $hostlist,
+  Array[String]      $users                   = [],
+  Array[String]      $groups                  = [],
+  Hash[String, Data] $additional_match_params = {},
 ) {
-
   # CHECK INPUT
   if empty( $users ) and empty( $groups ) {
     fail( "'users' and 'groups' cannot both be empty" )
   }
 
-
   # ACCESS.CONF
   ### This sets up the pam access.conf file to allow incoming ssh
   $groups.each |String $group| { $hostlist.each |String $host| {
-    pam_access::entry { "Allow group ${group} ssh from ${host}":
-      group      => $group,
-      origin     => $host,
-      permission => '+',
-      position   => '-1',
-    }
-  }}
+      pam_access::entry { "Allow group ${group} ssh from ${host}":
+        group      => $group,
+        origin     => $host,
+        permission => '+',
+        position   => '-1',
+      }
+  } }
 
   $users.each |String $user| { $hostlist.each |String $host| {
-    pam_access::entry { "Allow user ${user} ssh from ${host}":
-      user       => $user,
-      origin     => $host,
-      permission => '+',
-      position   => '-1',
-    }
-  }}
-
+      pam_access::entry { "Allow user ${user} ssh from ${host}":
+        user       => $user,
+        origin     => $host,
+        permission => '+',
+        position   => '-1',
+      }
+  } }
 
   ### FIREWALL
   $hostlist.each | $host | {
@@ -83,7 +80,6 @@ define sshd::allow_from (
     }
   }
 
-
   ### SSSD
   # Requires custom fact 'sssd_domains'
   # See: lib/augeasfacter/sssd_info.conf
@@ -92,7 +88,7 @@ define sshd::allow_from (
   # convert sssd domains from csv string to a puppet array
   $domains = $facts['sssd_domains'] ? {
     String[1] => $facts['sssd_domains'].regsubst(/ +/, '', 'G').split(','),
-    default   =>  [],
+    default   => [],
   }
   $domains.each |$domain| {
     if $users =~ Array[String,1] {
@@ -130,11 +126,11 @@ define sshd::allow_from (
 
   # Create cfg_match_params for Users and Groups
   $user_params = $users ? {
-    Array[ String, 1 ] => { 'AllowUsers' => $users },
+    Array[String, 1] => { 'AllowUsers' => $users },
     default            => {}
   }
   $group_params = $groups ? {
-    Array[ String, 1 ] => { 'AllowGroups' => $groups },
+    Array[String, 1] => { 'AllowGroups' => $groups },
     default            => {}
   }
 
@@ -160,7 +156,7 @@ define sshd::allow_from (
 
   # Create User match criteria (empty if user list is empty)
   $user_csv = $users ? {
-    Array[ String, 1 ] => join( $users, ',' ),
+    Array[String, 1] => join( $users, ',' ),
     default            => '',
   }
   $user_criteria = $user_csv ? {
@@ -169,7 +165,7 @@ define sshd::allow_from (
   }
   # Create Group match criteria (empty if group list is empty)
   $group_csv = $groups ? {
-    Array[ String, 1 ] => join( $groups, ',' ),
+    Array[String, 1] => join( $groups, ',' ),
     default            => '',
   }
   $group_criteria = $group_csv ? {
@@ -194,7 +190,7 @@ define sshd::allow_from (
     # }
 
     #add parameters to the match block
-    $config_data = $cfg_match_params.reduce( {} ) | $memo, $kv | {
+    $config_data = $cfg_match_params.reduce({}) | $memo, $kv | {
       $key = $kv[0]
       $val = $kv[1]
       $memo + {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,9 +162,8 @@ class sshd (
   Array             $trusted_subnets,
   Optional[String]  $banner = undef,
 ) {
-
   # PACKAGES
-  ensure_packages( $required_packages, {'ensure' => 'present'} )
+  ensure_packages( $required_packages, { 'ensure' => 'present' })
 
   # SERVICE
   if ( $manage_service ) {
@@ -173,11 +172,11 @@ class sshd (
       enable     => true,
       hasstatus  => true,
       hasrestart => true,
-      require    => Package[ $required_packages ],
+      require    => Package[$required_packages],
     }
     # SET DEFAULTS TO NOTIFY SERVICE
     $config_defaults = {
-      'notify' => Service[$service_name] ,
+      'notify' => Service[$service_name],
     }
   } else {
     # SET DEFAULTS TO SKIP NOTIFY SERVICE
@@ -199,14 +198,14 @@ class sshd (
 
   # SSHD CONFIG SETTINGS
 #  if ( $config_defaults ) {
-    $config_match_defaults = $config_defaults + { 'position' => 'before first match' }
+  $config_match_defaults = $config_defaults + { 'position' => 'before first match' }
 #  } else {
 #    $config_match_defaults = { 'position' => 'before first match' }
 #  }
 
   # REVOKED KEYS
   file { $revoked_keys_file :
-    ensure  => present,
+    ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0644',
@@ -215,17 +214,17 @@ class sshd (
   sshd_config {
     'RevokedKeys' :
       value => $revoked_keys_file,
-    ;
+      ;
     default:
       * => $config_defaults,
-    ;
+      ;
   }
 
   $puppet_file_header = '# This file is managed by Puppet - Changes may be overwritten'
   exec { 'add puppet header to sshd_config':
     command => "sed -i '1s/^/${puppet_file_header}\\n/' '${config_file}'",
     unless  => "grep '${puppet_file_header}' ${config_file}",
-    path    => [ '/bin', '/usr/bin' ],
+    path    => ['/bin', '/usr/bin'],
   }
 
   # Apply global sshd_config settings
@@ -233,10 +232,10 @@ class sshd (
     sshd_config {
       $key :
         value => $val,
-      ;
+        ;
       default:
         * => $config_defaults,
-      ;
+        ;
     }
   }
 
@@ -245,10 +244,10 @@ class sshd (
     # Create config match section
     sshd_config_match {
       $condition :
-      ;
+        ;
       default:
         * => $config_match_defaults,
-      ;
+        ;
     }
     # Set each setting inside the match section
     $data.each | $key, $val | {
@@ -257,10 +256,10 @@ class sshd (
           key       => $key,
           value     => $val,
           condition => $condition,
-        ;
+          ;
         default:
           * => $config_defaults,
-        ;
+          ;
       }
     }
   }
@@ -283,10 +282,10 @@ class sshd (
       sshd_config {
         'Banner' :
           value => '/etc/sshbanner',
-        ;
+          ;
         default:
           * => $config_defaults,
-        ;
+          ;
       }
     }
   }
@@ -296,11 +295,10 @@ class sshd (
     sshd_config_subsystem {
       $key :
         command => $val,
-      ;
+        ;
       default:
         * => $config_defaults,
-      ;
+        ;
     }
   }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
-  "pdk-version": "2.3.0",
-  "template-url": "pdk-default#2.3.0",
-  "template-ref": "tags/2.3.0-0-g8aaceff"
+  "pdk-version": "2.7.1",
+  "template-url": "pdk-default#2.7.4",
+  "template-ref": "tags/2.7.4-0-g58edf57"
 }


### PR DESCRIPTION
NOTE: If you manually turned on verbose SFTP sshd subsystem in your project's control repo by setting:
sshd::config_subsystems:
  sftp: "/usr/libexec/openssh/sftp-server -l VERBOSE"
You can now remove that

Also update pdk version to 2.7.1 to get github action working again