### PR TITLE
SVCPLAN-8811: CAUTION: handle Red Hat 9 drop-in files

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -37,6 +37,9 @@ The following parameters are available in the `sshd` class:
 * [`config_file`](#-sshd--config_file)
 * [`config_matches`](#-sshd--config_matches)
 * [`config_subsystems`](#-sshd--config_subsystems)
+* [`disable_dropin_configs`](#-sshd--disable_dropin_configs)
+* [`disable_dropin_configs_dir`](#-sshd--disable_dropin_configs_dir)
+* [`dropin_configs_dir`](#-sshd--dropin_configs_dir)
 * [`manage_service`](#-sshd--manage_service)
 * [`required_packages`](#-sshd--required_packages)
 * [`revoked_keys`](#-sshd--revoked_keys)
@@ -189,6 +192,25 @@ Data type: `Hash`
 
 Hash of sshd subsystems to enable and configure
 
+##### <a name="-sshd--disable_dropin_configs"></a>`disable_dropin_configs`
+
+Data type: `Array[String]`
+
+List of drop-in config files to disable/rename (OS-specific). Just file name, which
+are relative to the dropin_configs_dir (below).
+
+##### <a name="-sshd--disable_dropin_configs_dir"></a>`disable_dropin_configs_dir`
+
+Data type: `String`
+
+Folder for storing disabled drop-in config files.
+
+##### <a name="-sshd--dropin_configs_dir"></a>`dropin_configs_dir`
+
+Data type: `String`
+
+Folder where "active" drop-in configs live.
+
 ##### <a name="-sshd--manage_service"></a>`manage_service`
 
 Data type: `Boolean`
@@ -199,7 +221,7 @@ Flag of whether to manage sshd service
 
 Data type: `Array[String]`
 
-List of package names to be installed (OS specific).
+List of package names to be installed (OS-specific).
 (Defaults provided by module should be sufficient).
 
 ##### <a name="-sshd--revoked_keys"></a>`revoked_keys`

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,6 +19,9 @@ sshd::allow_list: {}
 sshd::banner_ignore: false
 sshd::config_file: "/etc/ssh/sshd_config"
 sshd::config_matches: {}
+sshd::disable_dropin_configs: []
+sshd::disable_dropin_configs_dir: "/etc/ssh/sshd_config.disabled"
+sshd::dropin_configs_dir: "/etc/ssh/sshd_config.d"
 sshd::manage_service: true
 sshd::revoked_keys: []
 sshd::trusted_subnets: []

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -5,11 +5,18 @@ sshd::config:
   AuthenticationMethods: "none"
   DenyGroups:
     - "all_disabled_usr"
+  Include: "/etc/ssh/sshd_config.d/*.conf /etc/crypto-policies/back-ends/opensshserver.config"
   PermitRootLogin: "no"
+  PrintMotd: "no"
   PubkeyAuthentication: "no"
   UsePAM: "yes"
+  X11Forwarding: "no"
 sshd::config_subsystems:
   sftp: "/usr/libexec/openssh/sftp-server -l VERBOSE"
+sshd::disable_dropin_configs:
+  - "01-permitrootlogin.conf"
+  - "40-redhat-crypto-policies.conf"
+  - "50-redhat.conf"
 sshd::required_packages:
   - "openssh-server"
 sshd::revoked_keys_file: "/etc/ssh/revoked_keys"

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -22,6 +22,7 @@ sshd::config:
     - "/etc/ssh/ssh_host_ecdsa_key"
     - "/etc/ssh/ssh_host_ed25519_key"
     - "/etc/ssh/ssh_host_rsa_key"
+  Include: null
   KerberosAuthentication: "no"
   KexAlgorithms:
     - "curve25519-sha256"
@@ -41,6 +42,8 @@ sshd::config:
   MaxAuthTries: "2"
   PasswordAuthentication: "no"
   PermitRootLogin: "no"
+  PrintMotd: "yes"
   PubkeyAuthentication: "no"
   SyslogFacility: "AUTHPRIV"
   UseDNS: "no"
+sshd::disable_dropin_configs: []

--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -14,6 +14,7 @@ sshd::config:
     - "/etc/ssh/ssh_host_ecdsa_key"
     - "/etc/ssh/ssh_host_ed25519_key"
     - "/etc/ssh/ssh_host_rsa_key"
+  Include: "/etc/ssh/sshd_config.d/*.conf"
   KerberosAuthentication: "no"
   LogLevel: "VERBOSE"
   MaxAuthTries: "2"
@@ -22,3 +23,4 @@ sshd::config:
   PubkeyAuthentication: "no"
   SyslogFacility: "AUTHPRIV"
   UseDNS: "no"
+sshd::disable_dropin_configs: []


### PR DESCRIPTION
Red Hat 9 includes the following by default:
/etc/ssh/sshd_config.d/50-redhat.conf

This introduces global settings in a file that was not previously managed by Puppet.

Update defaults for Red Hat 9 to manage a couple of those settings and to rename/disable this file.
- functional change: 'X11Forwarding no'
- functional change: 'GSSAPIAuthentication no'

Also rename/disable a similar 01-permitrootlogin.conf, if present.
- functional change: 'PermitRootLogin no'
- this file is only generally present on stateful nodes and likely only (some of) those installed via the Red Hat Anaconda OS installer

NOTE: We typically enable these things where needed in match blocks, so there's not a huge likelihood of breaking things with this update, but please review the settings in your control repo / on your nodes.